### PR TITLE
Count cycles using uint64_t

### DIFF
--- a/z80.h
+++ b/z80.h
@@ -13,7 +13,7 @@ struct z80 {
   void (*port_out)(z80*, uint8_t, uint8_t);
   void* userdata;
 
-  unsigned long cyc; // cycle count (t-states)
+  uint64_t cyc; // cycle count (t-states)
 
   uint16_t pc, sp, ix, iy; // special purpose registers
   uint16_t mem_ptr; // "wz" register


### PR DESCRIPTION
This will guarantee cycles are counted using a 64-bit integer and is consistent with the other types being used in the project.