### PR TITLE
Fix timing of BIT (HL) and OTDR instructions

### DIFF
--- a/z80.c
+++ b/z80.c
@@ -1449,12 +1449,9 @@ void exec_opcode_cb(z80* const z, uint8_t opcode) {
   case 3: *reg |= 1 << y_; break; // SET y, r[z]
   }
 
-  if ((x_ == 0 || x_ == 2 || x_ == 3) && z_ == 6) {
-    z->cyc += 7;
-  }
-
-  if (reg == &hl) {
+  if ((x_ != 1) && (z_ == 6)) { // BIT (HL) not included
     wb(z, get_hl(z), hl);
+    z->cyc += 7;
   }
 }
 
@@ -1657,6 +1654,7 @@ void exec_opcode_ed(z80* const z, uint8_t opcode) {
     outd(z);
     if (z->b > 0) {
       z->pc -= 2;
+      z->cyc += 5;
     }
   } break; // otdr
 


### PR DESCRIPTION
This pull request fixes the timing for BIT (HL) and OTDR. The problem with OTDR was discovered using a Sega Master System timing test ROM, and the problem with BIT (HL) was discovered in both tech demos and many Konami games for the Sega Mega Drive. It seems ZEXALL/ZEXDOC do not actually test every case.

I should add that this Z80 emulator, with my modifications, can run every game in the ColecoVision, Sega SG-1000, Sega Master System, and Game Gear libraries. It also works perfectly in every Sega Mega Drive game I have tested.

Relevant links:
https://gitlab.com/carmiker/sms-test-roms/-/blob/master/cputimer.sms - SMS CPU timing test ROM
https://gitlab.com/jgemu/cega - Sega 8-bit emulator using this Z80 core (to 0.4.0)
https://gitlab.com/jgemu/jollycv - ColecoVision emulator using this Z80 core